### PR TITLE
feat: add contains automaton

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fst"
-version = "0.4.7"  #:version
+version = "0.4.8" #:version
 authors = ["Andrew Gallant <jamslam@gmail.com>"]
 description = """
 Use finite state transducers to compactly represents sets or maps of many
@@ -19,8 +19,9 @@ members = ["bench", "fst-bin"]
 exclude = ["fst-levenshtein", "fst-regex"]
 
 [features]
-default = []
+default = ["levenshtein", "contains"]
 levenshtein = ["utf8-ranges"]
+contains = ["utf8-ranges"]
 
 [patch.crates-io]
 fst = { path = "." }

--- a/examples/contains.rs
+++ b/examples/contains.rs
@@ -4,7 +4,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let paths = vec!["a foo bar", "foo", "foo1", "foo12", "foo3", "foobar"];
     let set = Set::from_iter(paths)?;
 
-    // Build our prefix query.
+    // Build our contains query.
     let prefix = Contains::new("foob");
 
     // Apply our query to the set we built.

--- a/examples/contains.rs
+++ b/examples/contains.rs
@@ -1,0 +1,16 @@
+use fst::{automaton::Contains, IntoStreamer, Set};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let paths = vec!["a foo bar", "foo", "foo1", "foo12", "foo3", "foobar"];
+    let set = Set::from_iter(paths)?;
+
+    // Build our prefix query.
+    let prefix = Contains::new("foob");
+
+    // Apply our query to the set we built.
+    let stream = set.search(&prefix).into_stream();
+
+    let matches = stream.into_strs()?;
+    println!("{:?}", matches);
+    Ok(())
+}

--- a/src/automaton/contains.rs
+++ b/src/automaton/contains.rs
@@ -1,0 +1,78 @@
+use crate::automaton::{Automaton, StartsWith};
+
+/// An automaton that matches if the input contains to a specific string.
+///
+/// ```rust
+/// extern crate fst;
+///
+/// use fst::{Automaton, IntoStreamer, Streamer, Set};
+/// use fst::automaton::Contains;
+///
+/// # fn main() { example().unwrap(); }
+/// fn example() -> Result<(), Box<dyn std::error::Error>> {
+///     let paths = vec!["/home/projects/bar", "/home/projects/foo", "/tmp/foo"];
+///     let set = Set::from_iter(paths)?;
+///
+///     // Build our contains query.
+///     let keyword = Contains::new("/projects");
+///
+///     // Apply our query to the set we built.
+///     let mut stream = set.search(keyword).into_stream();
+///
+///     let matches = stream.into_strs()?;
+///     assert_eq!(matches, vec!["/home/projects/bar", "/home/projects/foo"]);
+///     Ok(())
+/// }
+/// ```
+#[derive(Clone, Debug)]
+pub struct Contains<'a> {
+    string: &'a [u8],
+}
+
+impl<'a> Contains<'a> {
+    /// Constructs automaton that matches an exact string.
+    #[inline]
+    pub fn new(string: &'a str) -> StartsWith<Contains<'a>> {
+        Self { string: string.as_bytes() }.starts_with()
+    }
+}
+
+impl<'a> Automaton for Contains<'a> {
+    type State = Option<usize>;
+
+    #[inline]
+    fn start(&self) -> Option<usize> {
+        Some(0)
+    }
+
+    #[inline]
+    fn is_match(&self, pos: &Option<usize>) -> bool {
+        pos.is_some() && pos.unwrap() >= self.string.len()
+    }
+
+    #[inline]
+    fn can_match(&self, pos: &Option<usize>) -> bool {
+        pos.is_some()
+    }
+
+    #[inline]
+    fn accept(&self, pos: &Option<usize>, byte: u8) -> Option<usize> {
+        // if we aren't already past the end...
+        if let Some(pos) = *pos {
+            // and there is still a matching byte at the current position...
+            if self.string.get(pos).cloned() == Some(byte) {
+                // then move forward
+                return Some(pos + 1);
+            } else {
+                if pos >= self.string.len() {
+                    // if we're past the end, then we're done
+                    return Some(i32::MAX as usize);
+                } else {
+                    return Some(0);
+                }
+            }
+        }
+        // otherwise we're either past the end or didn't match the byte
+        None
+    }
+}

--- a/src/automaton/mod.rs
+++ b/src/automaton/mod.rs
@@ -1,8 +1,17 @@
+
+#[cfg(feature = "contains")]
+pub use self::contains::Contains;
+
+#[cfg(feature = "contains")]
+mod contains;
+
 #[cfg(feature = "levenshtein")]
 pub use self::levenshtein::{Levenshtein, LevenshteinError};
 
 #[cfg(feature = "levenshtein")]
 mod levenshtein;
+
+
 
 /// Automaton describes types that behave as a finite automaton.
 ///


### PR DESCRIPTION
I added a `contains` automaton, then you can search keyword contains in some terms.

```Rust
use fst::{automaton::Contains, IntoStreamer, Set};

fn main() -> Result<(), Box<dyn std::error::Error>> {
    let paths = vec!["a foo bar", "foo", "foo1", "foo12", "foo3", "foobar"];
    let set = Set::from_iter(paths)?;

    // Build our contains query.
    let prefix = Contains::new("foob");

    // Apply our query to the set we built.
    let stream = set.search(&prefix).into_stream();

    let matches = stream.into_strs()?;
    println!("{:?}", matches);
    // ["foobar"]
    Ok(())
}
```

Or you can simple run the example:
```
cargo run --example contains
```